### PR TITLE
Retooled the server.js from the code blog, ripping out the proxy code…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 notes
 **/.DS_Store
-**/githubToken.js
-scTokens
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "warrior-meditation",
+  "version": "1.0.0",
+  "description": "Insert description here. :-p",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "Code Fellows",
+  "license": "ISC",
+  "dependencies": {
+    "express": "^4.13.3",
+    "pushstate-server": "^1.8.1"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,13 @@
+var express = require('express'),
+  port = process.env.PORT || 3000,
+  app = express();
+
+app.use(express.static('./'));
+
+app.get('*', function(request, response) {
+  response.sendFile('index.html', { root: '.' });
+});
+
+app.listen(port, function() {
+  console.log('Server started on port ' + port + '!');
+});


### PR DESCRIPTION
… and package.

I stripped out the unnecessary code from server.js. I've tested it locally and on Heroku. Each developer will need to execute `node install` from their local repository to get node to build out the server based on the packages.js and server.js.
